### PR TITLE
build: Use pulseaudio version from meson

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -15,14 +15,13 @@ pa_c_args = ['-DHAVE_CONFIG_H']
 dbus_dep = dependency('dbus-1', version : '>= 1.2', required : true)
 pulsecore_dep = dependency('pulsecore', version : '>= 14.2', required : true)
 
-pa_version_str = meson.project_version()
+pa_version_str = pulsecore_dep.version()
 # For tarballs, the first split will do nothing, but for builds in git, we
 # split out suffixes when there are commits since the last tag
 # (e.g.: v11.99.1-3-gad14bdb24 -> v11.99.1)
 version_split = pa_version_str.split('-')[0].split('.')
 pa_version_major = version_split[0].split('v')[0]
 pa_version_minor = version_split[1]
-pa_version_module = version_split[2].split('+')[0]
 pa_version_major_minor = pa_version_major + '.' + pa_version_minor
 
 libdir = join_paths(get_option('prefix'), get_option('libdir'))

--- a/rpm/pulseaudio-module-keepalive.spec
+++ b/rpm/pulseaudio-module-keepalive.spec
@@ -30,6 +30,5 @@ echo "%{moduleversion}" > .tarball-version
 %meson_install
 
 %files
-%defattr(-,root,root,-)
-%{_libdir}/pulse-%{pulsemajorminor}/modules/module-keepalive.so
+%{_libdir}/pulse-*/modules/module-keepalive.so
 %license COPYING


### PR DESCRIPTION
Makes build easier when updating pulseaudio.
Remove not needed defattr from spec.